### PR TITLE
Fix url params

### DIFF
--- a/fliphtml5_downloader.py
+++ b/fliphtml5_downloader.py
@@ -41,7 +41,7 @@ useragents = [
 
 # Fetch configuration from a remote URL
 def fetch_config():
-    config_url = f"https://online.fliphtml5.com/okyip/cpcr/javascript/config.js?{bookID}"
+    config_url = f"https://online.fliphtml5.com/{bookID}/javascript/config.js"
     headers = {'User-Agent': random.choice(useragents)}
     try:
         r = requests.get(config_url, headers=headers, timeout=50)
@@ -70,7 +70,7 @@ def download_image(taskID):
     taskID = clean_taskID(taskID)  # Clean the taskID
     for ext in ['jpg', 'webp' ]:  # Try webp first, then jpg
         filepath = f"{folderName}/{taskID}.{ext}"
-        URL = f"https://online.fliphtml5.com/okyip/cpcr/files/large/{taskID}.{ext}"
+        URL = f"https://online.fliphtml5.com/{bookID}/files/large/{taskID}.{ext}"
         headers = {'User-Agent': random.choice(useragents)}
 
         try:


### PR DESCRIPTION
There was likely a change in the API and downloading a book correctly now requires using the book’s actual ID in the URL instead of what looked like a placeholder (`okyip/cpcr`).  (Originally no matter what book ID I tried the program would always give me the same book, the one with that placeholder ID)

It seems the `config.js` request’s URL parameter was originally intended to tell the API which book to fetch, but that no longer affects the response. Adding the book ID directly to the URL now appears to be the only method that works.

Please correct me if I misunderstood what this code was supposed to do / unintentionally broke something else.